### PR TITLE
fix: ECHConfigList encoded in Base64 for presentation format

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `svcb_rr_patch` is the patch that adds SVCB Resource Record and HTTPS Resource Record.
 
-- https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-06
+- https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-06
 
 `svcb_rr_patch` supports "ech" SvcParamKey that ECHConfig.version is 0xfe0a.
 
@@ -33,7 +33,7 @@ irb(main):001:0> require 'svcb_rr_patch'
 irb(main):002:1* Resolv::DNS.new.getresources(
 irb(main):003:1*   "blog.cloudflare.com",
 irb(main):004:1*   Resolv::DNS::Resource::IN::HTTPS
-irb(main):005:0> ) { |rr| pp rr }
+irb(main):005:0> )
 => [#<Resolv::DNS::Resource::IN::HTTPS:0x0000000000000001 @svc_priority=1, @svc_domain_name="", @svc_field_value={"alpn"=>#<SvcbRrPatch::SvcParams::Alpn:0x0000000000000002 @protocols=["h3-29", "h3-28", "h3-27", "h2"]>, "ipv4hint"=>#<SvcbRrPatch::SvcParams::Ipv4hint:0x0000000000000003 @addresses=[#<Resolv::IPv4 104.18.26.46>, #<Resolv::IPv4 104.18.27.46>]>, "ipv6hint"=>#<SvcbRrPatch::SvcParams::Ipv6hint:0x0000000000000004 @addresses=[#<Resolv::IPv6 2606:4700::6812:1a2e>, #<Resolv::IPv6 2606:4700::6812:1b2e>]>}, @ttl=300>]
 ```
 

--- a/lib/svcb_rr_patch.rb
+++ b/lib/svcb_rr_patch.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'base64'
 require 'resolv'
 
 require 'svcb_rr_patch/version'

--- a/lib/svcb_rr_patch/svc_params/ech.rb
+++ b/lib/svcb_rr_patch/svc_params/ech.rb
@@ -23,7 +23,8 @@ class SvcbRrPatch::SvcParams::Ech
   end
 
   # https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-06#section-9
-  # In presentation format, the value is a single ECHConfigList encoded in Base64.
+  # In presentation format, the value is a single ECHConfigList encoded in
+  # Base64.
   def inspect
     Base64.strict_encode64(encode)
   end

--- a/lib/svcb_rr_patch/svc_params/ech.rb
+++ b/lib/svcb_rr_patch/svc_params/ech.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SvcbRrPatch::SvcParams::Ech
-  attr_reader :echconfigs
+  attr_reader :echconfiglist
 
   # @param echconfiglist [Array of ECHConfig]
   def initialize(echconfiglist)
@@ -20,6 +20,12 @@ class SvcbRrPatch::SvcParams::Ech
 
     echconfiglist = ECHConfig.decode_vectors(octet.slice(2..))
     new(echconfiglist)
+  end
+
+  # https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-06#section-9
+  # In presentation format, the value is a single ECHConfigList encoded in Base64.
+  def inspect
+    Base64.strict_encode64(encode)
   end
 end
 


### PR DESCRIPTION
ref: https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-06#section-9

> In presentation format, the value is a single ECHConfigList encoded in Base64 [base64].  Base64 is used here to simplify integration with TLS server software.  To enable simpler parsing, this SvcParam MUST NOT contain escape sequences.