### PR TITLE
improvement: update for draft-ietf-tls-esni-{10 => 13}

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@
 
 - https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-06
 
-`svcb_rr_patch` supports "ech" SvcParamKey that ECHConfig.version is 0xfe0a.
+`svcb_rr_patch` supports "ech" SvcParamKey that ECHConfig.version is `0xfe0d`.
 
-- https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-10#section-4
+- https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-13#section-4
 
 
 ## Installation
 
 he gem is available at [rubygems.org](https://rubygems.org/gems/svcb_rr_patch). You can install it the following.
 
-```bash
+```sh-session
 $ gem install svcb_rr_patch
 ```
 
@@ -26,7 +26,7 @@ $ gem install svcb_rr_patch
 
 You can resolve HTTPS resources.
 
-```bash
+```sh-session
 $ irb
 irb(main):001:0> require 'svcb_rr_patch'
 => true
@@ -34,7 +34,21 @@ irb(main):002:1* Resolv::DNS.new.getresources(
 irb(main):003:1*   "blog.cloudflare.com",
 irb(main):004:1*   Resolv::DNS::Resource::IN::HTTPS
 irb(main):005:0> )
-=> [#<Resolv::DNS::Resource::IN::HTTPS:0x0000000000000001 @svc_priority=1, @svc_domain_name="", @svc_field_value={"alpn"=>#<SvcbRrPatch::SvcParams::Alpn:0x0000000000000002 @protocols=["h3-29", "h3-28", "h3-27", "h2"]>, "ipv4hint"=>#<SvcbRrPatch::SvcParams::Ipv4hint:0x0000000000000003 @addresses=[#<Resolv::IPv4 104.18.26.46>, #<Resolv::IPv4 104.18.27.46>]>, "ipv6hint"=>#<SvcbRrPatch::SvcParams::Ipv6hint:0x0000000000000004 @addresses=[#<Resolv::IPv6 2606:4700::6812:1a2e>, #<Resolv::IPv6 2606:4700::6812:1b2e>]>}, @ttl=300>]
+=>
+[#<Resolv::DNS::Resource::IN::HTTPS:0x0000000000000001
+  @svc_params=
+   {"alpn"=>#<SvcbRrPatch::SvcParams::Alpn:0x0000000000000002 @protocols=["h2"]>,
+    "ipv4hint"=>
+     #<SvcbRrPatch::SvcParams::Ipv4hint:0x0000000000000003
+      @addresses=[#<Resolv::IPv4 162.159.135.79>, #<Resolv::IPv4 162.159.136.79>]>,
+    "ech"=>
+     AEb+DQBCkQAgACADmRYszCFsGObsrlyNdNRa9ygTgcGruqQ9+D2INQZfCwAEAAEAAQATY2xvdWRmbGFyZS1lc25pLmNvbQAA,
+    "ipv6hint"=>
+     #<SvcbRrPatch::SvcParams::Ipv6hint:0x0000000000000004
+      @addresses=[#<Resolv::IPv6 2606:4700:7::a29f:874f>, #<Resolv::IPv6 2606:4700:7::a29f:884f>]>},
+  @svc_priority=1,
+  @target_name="",
+  @ttl=300>]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ irb(main):005:0> )
 =>
 [#<Resolv::DNS::Resource::IN::HTTPS:0x0000000000000001
   @svc_params=
-   {"alpn"=>#<SvcbRrPatch::SvcParams::Alpn:0x0000000000000002 @protocols=["h2"]>,
+   {"alpn"=>
+     #<SvcbRrPatch::SvcParams::Alpn:0x0000000000000002
+      @protocols=["h3", "h3-29", "h3-28", "h3-27", "h2"]>,
     "ipv4hint"=>
      #<SvcbRrPatch::SvcParams::Ipv4hint:0x0000000000000003
-      @addresses=[#<Resolv::IPv4 162.159.135.79>, #<Resolv::IPv4 162.159.136.79>]>,
-    "ech"=>
-     AEb+DQBCkQAgACADmRYszCFsGObsrlyNdNRa9ygTgcGruqQ9+D2INQZfCwAEAAEAAQATY2xvdWRmbGFyZS1lc25pLmNvbQAA,
+      @addresses=[#<Resolv::IPv4 104.18.26.46>, #<Resolv::IPv4 104.18.27.46>]>,
     "ipv6hint"=>
      #<SvcbRrPatch::SvcParams::Ipv6hint:0x0000000000000004
-      @addresses=[#<Resolv::IPv6 2606:4700:7::a29f:874f>, #<Resolv::IPv6 2606:4700:7::a29f:884f>]>},
+      @addresses=[#<Resolv::IPv6 2606:4700::6812:1a2e>, #<Resolv::IPv6 2606:4700::6812:1b2e>]>},
   @svc_priority=1,
   @target_name="",
   @ttl=300>]

--- a/lib/svcb_rr_patch/https.rb
+++ b/lib/svcb_rr_patch/https.rb
@@ -9,7 +9,7 @@ class Resolv::DNS::Resource::IN::HTTPS < Resolv::DNS::Resource::IN::SVCB
   ClassHash[[TypeValue, ClassValue]] = self
 
   def initialize(svc_priority, target_name, svc_params)
-    # https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-06
+    # https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-06
     super(svc_priority, target_name, svc_params)
   end
 

--- a/lib/svcb_rr_patch/svc_params/ech/echconfig_contents.rb
+++ b/lib/svcb_rr_patch/svc_params/ech/echconfig_contents.rb
@@ -30,8 +30,8 @@ class SvcbRrPatch::SvcParams::Ech::ECHConfigContents
   # @return [String]
   def encode
     @key_config.encode \
-    + [@maximum_name_length].pack('n') \
-    + @public_name.then { |s| [s.length].pack('n') + s } \
+    + [@maximum_name_length].pack('C') \
+    + @public_name.then { |s| [s.length].pack('C') + s } \
     + @extensions.map(&:encode).join.then { |s| [s.length].pack('n') + s }
   end
 
@@ -42,12 +42,9 @@ class SvcbRrPatch::SvcParams::Ech::ECHConfigContents
     key_config, octet = HpkeKeyConfig.decode(octet)
     raise ::Resolv::DNS::DecodeError if octet.length < 2
 
-    maximum_name_length = octet.slice(0, 2).unpack1('n')
+    maximum_name_length = octet.slice(0, 1).unpack1('C')
+    pn_len = octet.slice(1, 1).unpack1('C')
     i = 2
-    raise ::Resolv::DNS::DecodeError if i + 2 > octet.length
-
-    pn_len = octet.slice(i, 2).unpack1('n')
-    i += 2
     raise ::Resolv::DNS::DecodeError if i + pn_len > octet.length
 
     public_name = octet.slice(i, pn_len)

--- a/lib/svcb_rr_patch/svc_params/ech/echconfig_contents.rb
+++ b/lib/svcb_rr_patch/svc_params/ech/echconfig_contents.rb
@@ -37,7 +37,6 @@ class SvcbRrPatch::SvcParams::Ech::ECHConfigContents
 
   # :nodoc
   # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
   def self.decode(octet)
     key_config, octet = HpkeKeyConfig.decode(octet)
     raise ::Resolv::DNS::DecodeError if octet.length < 2
@@ -67,5 +66,4 @@ class SvcbRrPatch::SvcParams::Ech::ECHConfigContents
     )
   end
   # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/lib/svcb_rr_patch/svcb.rb
+++ b/lib/svcb_rr_patch/svcb.rb
@@ -12,7 +12,7 @@ class Resolv::DNS::Resource::IN::SVCB < Resolv::DNS::Resource
   # @param target_name [String]
   # @param svc_params [Map]
   def initialize(svc_priority, target_name, svc_params)
-    # https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-06
+    # https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-06
     @svc_priority = svc_priority
     @target_name = target_name
     @svc_params = svc_params


### PR DESCRIPTION
`svcb_rr_patch` supports "ech" SvcParamKey that ECHConfig.version is `0xfe0d`.

- https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-10#section-4
- https://datatracker.ietf.org/doc/html/draft-ietf-tls-esni-13#section-4

```
-           uint16 maximum_name_length;
+           uint8 maximum_name_length;
...
-           opaque public_name<1..2^16-1>;
+           opaque public_name<1..255>;
```